### PR TITLE
correct implementation of designator parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ## Divergências em relação a especificação formal da linguagem
+- Na AST o PointerAccessExpression aceita apenas strings, mas deveria aceitar expression.
 - Parser em ANTLR suporta apenas literais de caracteres que correspondem a letras (por exemplo 'a' é suportado mas '7' não é).
 - Parser em ANTLR usa Id em diversos lugares em que deveria utilizar qualifiedName, por exemplo em PointerAccess.
 - Parser em ANTLR suporta(?) acesso de campo para expression, mas é especificado apenas acesso de campo para qualified identifier. O mesmo vale para acesso de lista.

--- a/src/main/scala/OberonAST.scala
+++ b/src/main/scala/OberonAST.scala
@@ -155,7 +155,6 @@ case class ArraySubscript(arrayBase: Expression, index: Expression) extends Expr
 case class Undef() extends Expression
 case class FieldAccessExpression(exp: Expression, name: String) extends Expression
 case class VarExpression(name: String) extends Expression
-case class GeneralFunctionCallExpression(expr: Expression, args: List[Expression]) extends Expression
 case class EQExpression(left:  Expression, right: Expression) extends Expression
 case class NEQExpression(left:  Expression, right: Expression) extends Expression
 case class GTExpression(left:  Expression, right: Expression) extends Expression

--- a/src/main/scala/OberonAST.scala
+++ b/src/main/scala/OberonAST.scala
@@ -138,6 +138,15 @@ case class CharValue(value: Char) extends Value { type T = Char }
 case class StringValue(value: String) extends Value { type T = String }
 case class BoolValue(value: Boolean) extends Value { type T = Boolean }
 
+sealed trait PointerAccess extends Expression
+case class PointerAccessExpression(name: String) extends PointerAccess
+case class ComplexPointerExpression(exp: Expression) extends PointerAccess
+
+sealed trait FunctionCall extends Expression
+case class FunctionCallExpression(name: String, args: List[Expression]) extends FunctionCall
+case class ComplexFunctionCallExpression(exp: Expression, args: List[Expression]) extends FunctionCall
+
+
 case object NullValue extends Expression
 case class Location(loc: Int) extends Expression
 case class Brackets(exp: Expression) extends Expression
@@ -145,9 +154,8 @@ case class ArrayValue(value: ListBuffer[Expression], arrayType: ArrayType) exten
 case class ArraySubscript(arrayBase: Expression, index: Expression) extends Expression
 case class Undef() extends Expression
 case class FieldAccessExpression(exp: Expression, name: String) extends Expression
-case class PointerAccessExpression(name: String) extends Expression
 case class VarExpression(name: String) extends Expression
-case class FunctionCallExpression(name: String, args: List[Expression]) extends Expression
+case class GeneralFunctionCallExpression(expr: Expression, args: List[Expression]) extends Expression
 case class EQExpression(left:  Expression, right: Expression) extends Expression
 case class NEQExpression(left:  Expression, right: Expression) extends Expression
 case class GTExpression(left:  Expression, right: Expression) extends Expression

--- a/src/main/scala/OberonParser.scala
+++ b/src/main/scala/OberonParser.scala
@@ -108,22 +108,6 @@ object OberonParser {
 	def expValueP: Parser[Expression] = 
 		decIntegerP | realP | charP | quoteStringP | boolP | nullP
 
-	def varExpressionP: Parser[VarExpression] = qualifiedNameP.map(VarExpression.apply)
-
-	def fieldAccessExprP(exprRecP: Parser[Expression]): Parser[Expression] =
-		((exprRecP.betweenParen | functionCallP(exprRecP).backtrack | varExpressionP) ~ (charTokenP('.') *> identifierP).rep)
-		.map { case (expr, names: NonEmptyList[String]) =>
-			names.toList.foldLeft(expr:Expression)((acc, name) => FieldAccessExpression(acc, name))
-		}
-
-	def arraySubscriptP(exprRecP: Parser[Expression]): Parser[ArraySubscript] =
-		(exprRecP ~ exprRecP.betweenBrackets)
-		.map(ArraySubscript.apply)
-
-	def pointerAccessP: Parser[PointerAccessExpression] =
-		(qualifiedNameP <* charTokenP('^'))
-		.map(PointerAccessExpression.apply)
-
 	def relationP: Parser[RelationOperator] =
 		stringTokenP("=").map(x => EQOperator) |
 		stringTokenP("#").map(x => NEQOperator) |

--- a/src/main/scala/OberonParser.scala
+++ b/src/main/scala/OberonParser.scala
@@ -151,30 +151,26 @@ object OberonParser {
 	def actualParametersP(exprRecP: Parser[Expression]): Parser[List[Expression]] =
 		exprListP(exprRecP).betweenParen
 
-	def toDesignator(desHelper: DesignatorHelper): Designator =
-		desHelper match {
-			case DesignatorHelper(name, Nil) => VarAssignment(name)
-			case DesignatorHelper(name, List(PointerSelector)) => PointerAssignment(name)
-			case DesignatorHelper(name, List(ArraySelector(index)))
-				=> ArrayAssignment(VarExpression(name), index)
-			case DesignatorHelper(name, List(FieldSelector(field))) 
-				=> RecordAssignment(VarExpression(name), field)
-			case x => {
-				println("ERRRO:");
-				println(x);
-				???
-				}
-		}
-
 	def selectorP(exprRecP: Parser[Expression]): Parser[Selector] =
 		(charTokenP('.') *> identifierP).map(FieldSelector.apply).backtrack |
 		exprRecP.betweenBrackets.map(ArraySelector.apply) |
 		charTokenP('^').map(_ => PointerSelector)
 
-	def designatorP(exprRecP: Parser[Expression]): Parser[Designator] = 
+	def designatorP(exprRecP: Parser[Expression]): Parser[DesignatorHelper] = 
 		(qualifiedNameP ~ selectorP(exprRecP).rep0)
 		.map(DesignatorHelper.apply)
-		.map(toDesignator)
+
+	def designatorHelperToExpression(designator: DesignatorHelper): Expression =
+		designator match {
+			case DesignatorHelper(name, selectors) =>
+				selectors.foldLeft(VarExpression(name): Expression){ (acc, value) =>
+					value match {
+						case PointerSelector => ComplexPointerExpression(acc)
+						case ArraySelector(index) => ArraySubscript(acc, index)
+						case FieldSelector(propName) => FieldAccessExpression(acc, propName)
+					}
+				}
+		}
 
 	def designatorToExpression(designator: Designator): Expression = 
 		designator match {
@@ -189,10 +185,12 @@ object OberonParser {
 		.map{ case (designator, optionParams) => 
 			optionParams match {
 				case Some(params) => designator match {
-					case VarAssignment(name) => FunctionCallExpression(name, params)
-					case _ => ???
+					case DesignatorHelper(name, Nil) => 
+					FunctionCallExpression(name, params)
+					case designator =>
+						ComplexFunctionCallExpression(designatorHelperToExpression(designator), params)
 				}
-				case None => designatorToExpression(designator)
+				case None => designatorHelperToExpression(designator)
 			}
 		
 		}

--- a/src/main/scala/OberonParser.scala
+++ b/src/main/scala/OberonParser.scala
@@ -178,6 +178,12 @@ object OberonParser {
 			}
 		
 		}
+		.map( expr => 
+			expr match {
+				case ComplexPointerExpression(VarExpression(name)) => PointerAccessExpression(name)
+				case _ => expr
+			}
+		)
 
 	def functionCallP(exprRecP: Parser[Expression]): Parser[FunctionCallExpression] =
 		(qualifiedNameP ~ actualParametersP(exprRecP))

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -61,8 +61,7 @@ class ParserTestSuite extends munit.FunSuite {
 			case _ => fail
 		}
 
-		val exprTest3 = expressionP.parseString("abc.array.abc")
-		println(exprTest3)
+		val exprTest3 = expressionP.parseString("abc[5][1+2].prop1")
 
 		val exprTest4 = expressionP.parseString("1 >= 2")
 		exprTest4 match {

--- a/src/test/scala/MySuite.scala
+++ b/src/test/scala/MySuite.scala
@@ -52,16 +52,16 @@ class ParserTestSuite extends munit.FunSuite {
 		exprTest1 match {
 			case Right("", expr) => assertEquals
 				(expr, AddExpression(IntValue(1), MultExpression(IntValue(2), IntValue(3))))
-			case _ => fail
+			case _ => fail("Expression test 1 failed")
 		}
 
 		val exprTest2 = expressionP.parseString(" - 1.23 + 5.68 - (4+2) = 5")
 		exprTest2 match {
 			case Right(str, _) => assert(str == "")
-			case _ => fail
+			case _ => fail("Expression test 2 failed")
 		}
 
-		val exprTest3 = expressionP.parseString("abc[5][1+2].prop1")
+		val exprTest3 = expressionP.parseString("a.b^")
 
 		val exprTest4 = expressionP.parseString("1 >= 2")
 		exprTest4 match {
@@ -103,19 +103,19 @@ class ParserTestSuite extends munit.FunSuite {
 		val multTest4 = multP.parseString("MOD 6 + 5")
 
 		multTest1 match {
-			case Left(_) => fail
+			case Left(_) => fail("Mult test 1 failed")
 			case Right(str, value) => assert(value == TimesOperator && str == "5")
 		}
 		multTest2 match {
-			case Left(_) => fail
+			case Left(_) => fail("Mult test 2 failed")
 			case Right(str, value) => assert(value == AndOperator && str == "True")
 		}
 		multTest3 match {
-			case Left(_) => fail
+			case Left(_) => fail("Mult test 3 failed")
 			case Right(str, value) => assert(value == SlashOperator && str == "3")
 		}
 		multTest4 match {
-			case Left(_) => fail
+			case Left(_) => fail("Mult test 4 failed")
 			case Right(str, value) => assert(value == ModOperator && str == "6 + 5")
 		}
 	}


### PR DESCRIPTION
The previous designator parser was full of bugs, for example the expression "abc.[5].prop[2]" did not parse correctly.
This pull request hopefully fixes this type of bug, but more tests involving several selectors are needed.

We also made the implementation more similar to the formal specification of the language, which makes it easier to avoid infinite loops when extending the current parser. A few changes and additions to the ast where made, but none of them should break compatibility with the ANTLR parser.